### PR TITLE
Add example Deepnote links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ If you want to received updates of these blogs in your mailbox, you can subscrib
 
 | Title        | Medium article           | Repository  |
 | ------------- |:-------------:| :-----:|
-| How to Create Fake Data with Faker | [link](https://towardsdatascience.com/how-to-create-fake-data-with-faker-a835e5b7a9d9) | [link](https://github.com/khuyentran1401/Data-science/blob/master/data_science_tools/faker.ipynb) |
-| Introduction to Schema: A Python Libary to Validate your Data | [link](https://towardsdatascience.com/introduction-to-schema-a-python-libary-to-validate-your-data-c6d99e06d56a) | [link](https://github.com/khuyentran1401/Data-science/blob/master/data_science_tools/schema.ipynb)
+| How to Create Fake Data with Faker | [link](https://towardsdatascience.com/how-to-create-fake-data-with-faker-a835e5b7a9d9) | [link](https://deepnote.com/launch?url=https://github.com/khuyentran1401/Data-science/blob/master/data_science_tools/faker.ipynb) |
+| Introduction to Schema: A Python Libary to Validate your Data | [link](https://towardsdatascience.com/introduction-to-schema-a-python-libary-to-validate-your-data-c6d99e06d56a) | [link](https://deepnote.com/launch?url=https://github.com/khuyentran1401/Data-science/blob/master/data_science_tools/schema.ipynb)
 |Introduction to DVC: Data Version Control Tool for Machine Learning Projects | [link](https://towardsdatascience.com/introduction-to-dvc-data-version-control-tool-for-machine-learning-projects-7cb49c229fe0) | [link](https://github.com/khuyentran1401/Machine-learning-pipeline) |
 | Introduction to Datasette: Explore and Publish Your Data in One Line of Code | [link](https://towardsdatascience.com/introduction-to-datasette-explore-and-publish-your-data-in-one-line-of-code-cbdc40cb4583)
 | Introduction to Datapane: A Python Library to Build Interactive Reports | [link](https://towardsdatascience.com/introduction-to-datapane-a-python-library-to-build-interactive-reports-4593fd3cb9c8) | 


### PR DESCRIPTION
Hey Khuyen,
Following up on the discussion with Elizabeth, I'm sending some examples of links that launch the notebooks in Deepnote. 

All you need to do is prepend the existing GitHub links with `https://deepnote.com/launch?url=` 

Links that point to an `.ipynb` file will open the right file. Those that point to a directory will clone the repository for the visitor in Deepnote, but they'll still need to navigate to the correct directory/files in the left-hand menu, which might be a bit confusing – so up to you if you want to include those.  

If you'd also like a button, you can add it like this:
```
[<img src="https://deepnote.com/buttons/launch-in-deepnote-small.svg">](https://deepnote.com/launch?url=https://github.com/khuyentran1401/Data-science)
```
[<img src="https://deepnote.com/buttons/launch-in-deepnote-small.svg">](https://deepnote.com/launch?url=https://github.com/khuyentran1401/Data-science)
